### PR TITLE
Restart animations

### DIFF
--- a/Aster/Private/Animation.cpp
+++ b/Aster/Private/Animation.cpp
@@ -21,9 +21,9 @@ Animation::Animation()
 }
 
 Animation::Animation(std::string filename, float speed)
-  : m_animationCursor(0),
-  m_spriteIndex(0),
-  m_speed(0.05f)
+    : m_animationCursor(0),
+      m_spriteIndex(0),
+      m_speed(0.05f)
 {
   std::string projectSrcDir = PROJECT_SOURCE_DIR;
 
@@ -37,11 +37,23 @@ Animation::Animation(std::string filename, float speed)
 
 Animation::~Animation()
 {
-
 }
 
-void Animation::Play(SpriteRenderer &renderer, Texture2D& texture, Rectangle& rectangle, double deltatime, glm::vec2 position, glm::vec2 size, float rotate, glm::vec3 color)
+void Animation::Play(SpriteRenderer &renderer,
+                     Texture2D &texture,
+                     Rectangle &rectangle,
+                     double deltatime,
+                     glm::vec2 position,
+                     glm::vec2 size,
+                     float rotate,
+                     glm::vec3 color,
+                     bool restartAnimation)
 {
+  if (restartAnimation)
+  {
+    m_spriteIndex = 0;
+  }
+
   m_animationCursor += deltatime;
 
   if (m_animationCursor > m_speed)
@@ -68,13 +80,13 @@ void Animation::Play(SpriteRenderer &renderer, Texture2D& texture, Rectangle& re
   int yExtraPos = frame[3] < 0 ? CELL_HEIGHT / 2 : 0;
 
   float vertices[] = {
-    0.0f,    yCells,   xSpritePos,                ySpritePos + spriteHeight,   //  3  2   //  2  3
-    xCells,  0.0f,     xSpritePos + spriteWidth,  ySpritePos,                  //         //
-    0.0f,    0.0f,     xSpritePos,                ySpritePos,                  //  1      //     1
+      0.0f, yCells, xSpritePos, ySpritePos + spriteHeight, //  3  2   //  2  3
+      xCells, 0.0f, xSpritePos + spriteWidth, ySpritePos,  //         //
+      0.0f, 0.0f, xSpritePos, ySpritePos,                  //  1      //     1
 
-    0.0f,    yCells,   xSpritePos,                ySpritePos + spriteHeight,   //     3   //  3
-    xCells,  yCells,   xSpritePos + spriteWidth,  ySpritePos + spriteHeight,   //         //
-    xCells,  0.0f,     xSpritePos + spriteWidth,  ySpritePos                   //  1  2   //  2  1
+      0.0f, yCells, xSpritePos, ySpritePos + spriteHeight,                 //     3   //  3
+      xCells, yCells, xSpritePos + spriteWidth, ySpritePos + spriteHeight, //         //
+      xCells, 0.0f, xSpritePos + spriteWidth, ySpritePos                   //  1  2   //  2  1
   };
 
   renderer.SetShader(glm::vec2(position.x + xExtraPos, position.y + yExtraPos), size, rotate, color);
@@ -88,8 +100,8 @@ void Animation::Play(SpriteRenderer &renderer, Texture2D& texture, Rectangle& re
   glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
 
   glEnableVertexAttribArray(0);
-  glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void*)0);
-  
+  glVertexAttribPointer(0, 4, GL_FLOAT, GL_FALSE, 4 * sizeof(float), (void *)0);
+
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 
   rectangle.Draw();

--- a/Aster/Private/Sprite.cpp
+++ b/Aster/Private/Sprite.cpp
@@ -15,24 +15,26 @@ Sprite::Sprite()
 
 Sprite::Sprite(std::string filename)
 {
-  m_texture = ResourceManager::GetInstance()->GetTexture(filename);
-  m_rectangle = RectangleSystem::GetInstance()->Generate();
-  m_hasAnimation = false;
+  Texture = ResourceManager::GetInstance()->GetTexture(filename);
+  SubspriteRectangle = RectangleSystem::GetInstance()->Generate();
+  HasAnimation = false;
 }
 
 Sprite::~Sprite()
 {
-  RectangleSystem::GetInstance()->Delete(m_rectangle);
+  RectangleSystem::GetInstance()->Delete(SubspriteRectangle);
 
-  m_animations.clear();
+  Animations.clear();
 }
 
 void Sprite::Draw(AnimationType type, SpriteRenderer &renderer, double deltatime, glm::vec2 position, glm::vec2 size = glm::vec2(10.0f, 10.0f), float rotate = 0.0f, glm::vec3 color = glm::vec3(1.0f))
 {
 
-  if (m_hasAnimation)
+  if (HasAnimation)
   {
-    m_animations[type]->Play(renderer, m_texture, m_rectangle, deltatime, position, size, rotate, color);
+    bool restartAnimation = CurrentAnimationType != type;
+    CurrentAnimationType = type;
+    Animations[type]->Play(renderer, Texture, SubspriteRectangle, deltatime, position, size, rotate, color, restartAnimation);
   }
   else
   {
@@ -42,16 +44,16 @@ void Sprite::Draw(AnimationType type, SpriteRenderer &renderer, double deltatime
 
 void Sprite::AddAnimation(std::string filename, AnimationType type, float speed)
 {
-  m_animations[type] = new Animation(filename, speed);;
-  m_hasAnimation = true;
+  Animations[type] = new Animation(filename, speed);
+  HasAnimation = true;
 }
 
 Texture2D Sprite::GetTexture()
 {
-  return m_texture;
+  return Texture;
 }
 
 glm::vec4 Sprite::GetAttackHitbox(AnimationType type)
 {
-  return m_animations[type]->GetAttackHitbox();
+  return Animations[type]->GetAttackHitbox();
 }

--- a/Aster/Public/Animation.h
+++ b/Aster/Public/Animation.h
@@ -8,20 +8,28 @@
 class Texture2D;
 struct Rectangle;
 class SpriteRenderer;
- 
+
 class Animation
 {
 public:
+  Animation();
+  Animation(std::string filename, float speed);
+  virtual ~Animation();
 
-	Animation();
-	Animation(std::string filename, float speed);
-	virtual ~Animation();
+  void Play(
+      SpriteRenderer &renderer,
+      Texture2D &texture,
+      Rectangle &rectangle,
+      double deltatime,
+      glm::vec2 position,
+      glm::vec2 size,
+      float rotate,
+      glm::vec3 color,
+      bool restartAnimation);
 
-  void Play(SpriteRenderer &renderer, Texture2D& texture, Rectangle& rectangle, double deltatime, glm::vec2 position, glm::vec2 size, float rotate, glm::vec3 color);
   glm::vec4 GetAttackHitbox();
 
 private:
-
   double m_animationCursor;
   int m_spriteIndex;
   int FramesCount;
@@ -29,5 +37,4 @@ private:
 
   std::vector<std::vector<int> > Frames;
   std::vector<std::vector<int> > HitboxFrames;
-
 };

--- a/Aster/Public/Sprite.h
+++ b/Aster/Public/Sprite.h
@@ -25,13 +25,13 @@ public:
 
 	void AddAnimation(std::string filename, AnimationType type, float speed);
 
-  Texture2D GetTexture();
-  glm::vec4 GetAttackHitbox(AnimationType);
+	Texture2D GetTexture();
+	glm::vec4 GetAttackHitbox(AnimationType);
 
 private:
-	Texture2D m_texture;
-	Rectangle m_rectangle;
-  bool m_hasAnimation;
-
-	std::map<AnimationType, Animation*> m_animations;
+	Texture2D Texture;
+	Rectangle SubspriteRectangle;
+	bool HasAnimation;
+	AnimationType CurrentAnimationType = AnimationType::IDLE;
+	std::map<AnimationType, Animation *> Animations;
 };


### PR DESCRIPTION
Si `Sprite` empieza a pintar una animacion diferente de la del frame anterior, se pasa a `Animation` un booleano que se usa para resetear el frame index de la animacion, de forma que empiece de 0 en mitad de por donde fuese la anterior