### PR TITLE
Fix double powerup on dash

### DIFF
--- a/Source/Entity/SpearPowerUp.cpp
+++ b/Source/Entity/SpearPowerUp.cpp
@@ -32,9 +32,9 @@ void SpearPowerUp::OnContact(
 		std::shared_ptr<Physics::PhysicActor> external,
 		std::shared_ptr<Physics::PhysicActor> internal)
 {
-	if (internal == ActorCollider && external->report->IsPlayer())
+	if (!IsDestroyed && internal == ActorCollider && external->report->IsPlayer())
 	{
 		IsDestroyed = true;
-		((Player*)(external->report))->PowerUp(PowerUpType::SPEAR);
+		((Player *)(external->report))->PowerUp(PowerUpType::SPEAR);
 	}
 }

--- a/Source/Entity/SwordPowerUp.cpp
+++ b/Source/Entity/SwordPowerUp.cpp
@@ -32,9 +32,9 @@ void SwordPowerUp::OnContact(
 		std::shared_ptr<Physics::PhysicActor> external,
 		std::shared_ptr<Physics::PhysicActor> internal)
 {
-	if (internal == ActorCollider && external->report->IsPlayer())
+	if (!IsDestroyed && internal == ActorCollider && external->report->IsPlayer())
 	{
 		IsDestroyed = true;
-		((Player*)(external->report))->PowerUp(PowerUpType::SWORD);
+		((Player *)(external->report))->PowerUp(PowerUpType::SWORD);
 	}
 }


### PR DESCRIPTION
Las colisiones estaban saltando cuando el player se chocaba con el powerup Y cuando el powerup se chocaba con el player. Checkeo si ya he destruido el powerup antes de aplicarselo al player (solo aplicarselo la primera vez)

![fix](https://trello-attachments.s3.amazonaws.com/60982c1d74da43386d0e846a/300x200/e6cb5db38ea3105535bed71756b01f13/out.gif)