### PR TITLE
Player Move refactor

### DIFF
--- a/Source/Entity/Player.cpp
+++ b/Source/Entity/Player.cpp
@@ -44,10 +44,12 @@ void Player::Update(float deltaTime, glm::vec4)
 			DashTime = 0;
 			SetState(ActorState::IDLE);
 		}
+
+		Actor::Move(deltaTime, LastMovementDirection);
 	}
-	else
+	else if (!IsBlockedByHammer())
 	{
-		Speed = BASE_SPEED;
+		Move(deltaTime, InputDirection);
 	}
 }
 
@@ -181,38 +183,32 @@ bool Player::IsInDashIFrames()
 	return (DashTime > DASH_IFRAMES_START) && (DashTime < DASH_IFRAMES_FINISH);
 }
 
+void Player::SetDirection(glm::vec3 direction)
+{
+	InputDirection = direction;
+}
+
 void Player::Move(float deltaTime, glm::vec3 direction)
 {
-	if (IsBlockedByHammer())
-	{
-		return;
-	}
-	else if (IsDashState())
-	{
-		Actor::Move(deltaTime, LastMovementDirection);
-	}
+	if (direction.x > 0)
+		SetState(ActorState::MOVEMENT_RIGHT);
+	else if (direction.x < 0)
+		SetState(ActorState::MOVEMENT_LEFT);
+	else if (direction.y > 0)
+		SetState(ActorState::MOVEMENT_DOWN);
+	else if (direction.y < 0)
+		SetState(ActorState::MOVEMENT_UP);
 	else
+		SetState(ActorState::IDLE);
+
+	MovementDirection = direction;
+
+	if (direction.x != 0 || direction.y != 0)
 	{
-		if (direction.x > 0)
-			SetState(ActorState::MOVEMENT_RIGHT);
-		else if (direction.x < 0)
-			SetState(ActorState::MOVEMENT_LEFT);
-		else if (direction.y > 0)
-			SetState(ActorState::MOVEMENT_DOWN);
-		else if (direction.y < 0)
-			SetState(ActorState::MOVEMENT_UP);
-		else
-			SetState(ActorState::IDLE);
-
-		MovementDirection = direction;
-
-		if (direction.x != 0 || direction.y != 0)
-		{
-			LastMovementDirection = direction;
-		}
-
-		Actor::Move(deltaTime, MovementDirection);
+		LastMovementDirection = direction;
 	}
+
+	Actor::Move(deltaTime, MovementDirection);
 }
 
 void Player::Dash(glm::vec3 direction)

--- a/Source/Entity/Player.cpp
+++ b/Source/Entity/Player.cpp
@@ -183,7 +183,7 @@ bool Player::IsInDashIFrames()
 	return (DashTime > DASH_IFRAMES_START) && (DashTime < DASH_IFRAMES_FINISH);
 }
 
-void Player::SetDirection(glm::vec3 direction)
+void Player::SetInputDirection(glm::vec3 direction)
 {
 	InputDirection = direction;
 }

--- a/Source/Entity/Player.h
+++ b/Source/Entity/Player.h
@@ -18,7 +18,7 @@ public:
 	void Update(float, glm::vec4) override;
 	void Draw(SpriteRenderer &renderer, double deltaTime) override;
 	void TakeDamage() override;
-	void Move(float deltaTime, glm::vec3 direction) override;
+	void SetDirection(glm::vec3 direction);
 	void Dash(glm::vec3 direction);
 	void SetDashSpeed();
 	void SetDashIFrames();
@@ -41,13 +41,16 @@ private:
 	AnimationType CurrentAnimation;
 	PowerUpType ActivePowerUp = PowerUpType::NONE;
 	float DashTime;
+	glm::vec3 InputDirection;
 	glm::vec3 MovementDirection;
 	glm::vec3 LastMovementDirection;
 
+	void Move(float deltaTime, glm::vec3 direction) override;
 	AnimationType GetAnimationFromState();
 	bool IsInDashIFrames();
 	bool IsAttackAnimationPlaying();
 	bool IsDashState();
 	bool IsBlockedByHammer();
 	bool IsHammerAttack();
+
 };

--- a/Source/Entity/Player.h
+++ b/Source/Entity/Player.h
@@ -18,7 +18,7 @@ public:
 	void Update(float, glm::vec4) override;
 	void Draw(SpriteRenderer &renderer, double deltaTime) override;
 	void TakeDamage() override;
-	void SetDirection(glm::vec3 direction);
+	void SetInputDirection(glm::vec3 direction);
 	void Dash(glm::vec3 direction);
 	void SetDashSpeed();
 	void SetDashIFrames();

--- a/Source/PlayerController.cpp
+++ b/Source/PlayerController.cpp
@@ -64,7 +64,7 @@ void PlayerController::ProcessInput(float deltaTime)
 			direction += glm::vec3(0.0f, 1.0f, 0.0f);
 		}
 
-		Character->SetDirection(direction);
+		Character->SetInputDirection(direction);
 
 		if (keys[GLFW_KEY_LEFT_SHIFT] && !keysProcessed[GLFW_KEY_LEFT_SHIFT])
 		{

--- a/Source/PlayerController.cpp
+++ b/Source/PlayerController.cpp
@@ -64,7 +64,7 @@ void PlayerController::ProcessInput(float deltaTime)
 			direction += glm::vec3(0.0f, 1.0f, 0.0f);
 		}
 
-		Character->Move(deltaTime, direction);
+		Character->SetDirection(direction);
 
 		if (keys[GLFW_KEY_LEFT_SHIFT] && !keysProcessed[GLFW_KEY_LEFT_SHIFT])
 		{


### PR DESCRIPTION
- Player controller llama ahora a `SetInputDirection` en vez de a `Move`
- `Player::Move` es privado, se llama desde `Player::Update`
- Extraido codigo de `Player::Move` a `Player::Update` para encargarse exclusivamente del movimiento. 